### PR TITLE
fix: [E404] Doesn't need a relative path in role

### DIFF
--- a/ansible/roles/anyenv/tasks/main.yml
+++ b/ansible/roles/anyenv/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: "nodenv default packages"
   copy:
-    src: ../files/nodenv-default-packages
+    src: nodenv-default-packages
     dest: "$HOME/.anyenv/envs/nodenv/default-packages"
 
 - name: "exist version in every envs"


### PR DESCRIPTION
[E404] Doesn't need a relative path in role

に対する修正