### PR TITLE
fix: [E305] Use shell only when shell functionality is required

### DIFF
--- a/ansible/roles/direnv/tasks/main.yml
+++ b/ansible/roles/direnv/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get direnv version
-  shell: direnv --version
+  command: direnv --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_direnv

--- a/ansible/roles/docker-compose/tasks/main.yml
+++ b/ansible/roles/docker-compose/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get docker_compose version
-  shell: docker-compose --version
+  command: docker-compose --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_docker_compose

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get docker version
-  shell: docker --version
+  command: docker --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_docker
@@ -18,7 +18,7 @@
 
 - block:
   - name: download repo
-    shell: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
 
   - name: install
     yum:

--- a/ansible/roles/embulk/tasks/main.yml
+++ b/ansible/roles/embulk/tasks/main.yml
@@ -10,7 +10,7 @@
   ignore_errors: true
 
 - name: get embulk version
-  shell: embulk --version
+  command: embulk --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_embulk

--- a/ansible/roles/git/tasks/main.yml
+++ b/ansible/roles/git/tasks/main.yml
@@ -15,7 +15,7 @@
   ignore_errors: true
 
 - name: get git version
-  shell: git --version
+  command: git --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_git

--- a/ansible/roles/jo/tasks/main.yml
+++ b/ansible/roles/jo/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get jo version
-  shell: jo -v
+  command: jo -v
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_jo

--- a/ansible/roles/peco/tasks/main.yml
+++ b/ansible/roles/peco/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get peco version
-  shell: peco --version
+  command: peco --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_peco

--- a/ansible/roles/tmux/tasks/main.yml
+++ b/ansible/roles/tmux/tasks/main.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get tmux version
-  shell: tmux -V
+  command: tmux -V
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_tmux

--- a/ansible/roles/zsh/tasks/source.yml
+++ b/ansible/roles/zsh/tasks/source.yml
@@ -7,7 +7,7 @@
   ignore_errors: true
 
 - name: get zsh version
-  shell: zsh --version
+  command: zsh --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH}}"
   register: version_in_zsh


### PR DESCRIPTION
 [E305] Use shell only when shell functionality is required

に対する修正

executeを使っていない箇所のみ

executeを使ってる場所は別途対応検討