### PR TITLE
fix: [E403] Package installs should not use latest

### DIFF
--- a/ansible/roles/powerline/tasks/main.yml
+++ b/ansible/roles/powerline/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: upgrade pip
-  pip: name=pip state=latest
+  pip: name=pip
 
 - name: install powerline
   # FIXME not idempotency because install login user. but not loaded zshenv via pip module


### PR DESCRIPTION
[E403] Package installs should not use latest

に対する修正