### PR TITLE
fix: ignore [E305] Use shell only when shell functionality is required

### DIFF
--- a/ansible/roles/anyenv/tasks/main.yml
+++ b/ansible/roles/anyenv/tasks/main.yml
@@ -24,14 +24,14 @@
   when: not anyenv_install_dir.stat.exists
 
 - name: "exist envs"
-  shell: "{{ execute }} 'which {{ item.key }}'"
+  shell: "{{ execute }} 'which {{ item.key }}'" # noqa 305
   register: exist_envs
   changed_when: false
   ignore_errors: true
   with_dict: "{{ envs }}"
 
 - name: "install envs"
-  shell: "{{ execute }} 'anyenv install {{ item.0 }}'"
+  shell: "{{ execute }} 'anyenv install {{ item.0 }}'" # noqa 305
   when: item.1.rc != 0
   with_together:
     - "{{ envs }}"
@@ -51,21 +51,21 @@
     dest: "$HOME/.anyenv/envs/nodenv/default-packages"
 
 - name: "exist version in every envs"
-  shell: "{{ execute }} '{{ item.key }} versions | grep {{ item.value.version }}'"
+  shell: "{{ execute }} '{{ item.key }} versions | grep {{ item.value.version }}'" # noqa 305
   register: exist_version
   changed_when: false
   ignore_errors: true
   with_dict: "{{ envs }}"
 
 - name: "install envs version"
-  shell: "{{ execute }} '{{ item.0 }} install {{ envs[item.0].version }}'"
+  shell: "{{ execute }} '{{ item.0 }} install {{ envs[item.0].version }}'" # noqa 305
   when: item.1.rc != 0
   with_together:
     - "{{ envs }}"
     - "{{ exist_version.results }}"
 
 - name: "exist global envs version"
-  shell: "{{ execute }} '{{ item.key }} global'"
+  shell: "{{ execute }} '{{ item.key }} global'" # noqa 305
   when: item.key != "goenv"
   register: exist_global
   changed_when: false
@@ -73,10 +73,8 @@
   with_dict: "{{ envs }}"
 
 - name: "set global envs version"
-  shell: "{{ execute }} '{{ item.0 }} global {{ envs[item.0].version }}'"
+  shell: "{{ execute }} '{{ item.0 }} global {{ envs[item.0].version }}'" # noqa 305
   when: item.1.stdout is defined and item.1.stdout.find(envs[item.0].version) == -1 and item.0 != 'goenv'
   with_together:
     - "{{ envs }}"
     - "{{ exist_global.results }}"
-
-

--- a/ansible/roles/powerline/tasks/main.yml
+++ b/ansible/roles/powerline/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: install powerline
   # FIXME not idempotency because install login user. but not loaded zshenv via pip module
   # pip: name="{{ item }}" state=present editable=false
-  shell: "{{ execute }} pip install {{ item }}"
+  shell: "{{ execute }} pip install {{ item }}" # noqa 305
   with_items:
     - psutil
     - "--upgrade git+git://github.com/powerline/powerline"


### PR DESCRIPTION
commandだとコマンドが実行できないためあえてshellにしている 

[E305] Use shell only when shell functionality is required

のチェックを除外した