### PR TITLE
fix: ignore [E303] git used in place of git module

### DIFF
--- a/ansible/roles/git/tasks/main.yml
+++ b/ansible/roles/git/tasks/main.yml
@@ -14,7 +14,7 @@
   changed_when: false
   ignore_errors: true
 
-- name: get git version
+- name: get git version # noqa 303
   command: git --version
   environment:
     PATH: "/usr/local/bin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
gitのバージョンを取得するためにコマンド発行しているのでlintからは除外