### PR TITLE
fix: warning  too few spaces before comment  (comments)

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -1,13 +1,5 @@
 ---
-# - hosts: local
-  # strategy: debug
-  # vars_files:
-  #   - common_vars.yml
-  # become: yes
-  # roles:
-  #   - { role: common, tags: common }
 - hosts: local
-  # strategy: debug
   vars_files:
     - common_vars.yml
   become: no


### PR DESCRIPTION
```
warning  too few spaces before comment  (comments)
```

の対応