### PR TITLE
feat: miseのtoolsを分割でインストールする

### DIFF
--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -30,8 +30,8 @@ jobs:
       - name: set json
         id: set-mise-tools
         run: |
-          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
-          chmod +x /usr/bin/yq
+          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
           MISE_TOOL_LIST=$(yq -o json -I=0 '.tools|keys' config/mise/config.toml)
           echo "list=$MISE_TOOL_LIST" >> "$GITHUB_OUTPUT"
  

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -44,15 +44,15 @@ jobs:
     steps:
       - uses: actions/github-script@v7.0.1
         id: set-matrix
+        env:
+          TOOLS_CHUNKS: ${{ vars.TOOLS_CHUNKS }}
         with:
           script: |
             const eventName = context.eventName;
             const targetTags = ['deploy', 'init', 'tool', 'mise'];
             const tags = (eventName === 'workflow_dispatch' || eventName === 'schedule') ? [...targetTags, 'all'] : targetTags;
-            console.log(tags);
             const tools = ${{ needs.set-mise-tools.outputs.list }};
-            console.log(tools);
-            const chunks = 3;
+            const chunks = process.env.TOOLS_CHUNKS || 3;
             const chunkedTools = Array.from({ length: chunks }, (_, i) => tools.slice(i * Math.ceil(tools.length / chunks), (i + 1) * Math.ceil(tools.length / chunks)));
             return tags.map(tag => {
               if (tag === "mise") {

--- a/.github/workflows/ci-ansible.yml
+++ b/.github/workflows/ci-ansible.yml
@@ -20,7 +20,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  set-mise-tools:
+    runs-on: ubuntu-latest
+    name: 'set mise tools list'
+    outputs:
+      list: ${{ steps.set-mise-tools.outputs.list }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: set json
+        id: set-mise-tools
+        run: |
+          wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          chmod +x /usr/bin/yq
+          MISE_TOOL_LIST=$(yq -o json -I=0 '.tools|keys' config/mise/config.toml)
+          echo "list=$MISE_TOOL_LIST" >> "$GITHUB_OUTPUT"
+ 
   set-tags-matrix:
+    needs: set-mise-tools
     runs-on: ubuntu-latest
     name: 'set tags matrix'
     outputs:
@@ -31,8 +47,19 @@ jobs:
         with:
           script: |
             const eventName = context.eventName;
-            const tags = ['deploy', 'init', 'tool', 'mise'];
-            return (eventName === 'workflow_dispatch' || eventName === 'schedule') ? [...tags, 'all'] : tags;
+            const targetTags = ['deploy', 'init', 'tool', 'mise'];
+            const tags = (eventName === 'workflow_dispatch' || eventName === 'schedule') ? [...targetTags, 'all'] : targetTags;
+            console.log(tags);
+            const tools = ${{ needs.set-mise-tools.outputs.list }};
+            console.log(tools);
+            const chunks = 3;
+            const chunkedTools = Array.from({ length: chunks }, (_, i) => tools.slice(i * Math.ceil(tools.length / chunks), (i + 1) * Math.ceil(tools.length / chunks)));
+            return tags.map(tag => {
+              if (tag === "mise") {
+                return chunkedTools.map(tool => ({tag, tools: tool.join(" ")}));
+              }
+              return {tag, tools: ''};
+            }).flat();
 
   build-ubuntu:
     needs: set-tags-matrix
@@ -41,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: ${{fromJson(needs.set-tags-matrix.outputs.tags)}}
+        row: ${{fromJson(needs.set-tags-matrix.outputs.tags)}}
     steps:
       - uses: actions/checkout@v4.2.2
       - if: github.event.client_payload
@@ -56,9 +83,10 @@ jobs:
       - name: run ansible
         env:
           CI: true
+          TOOLS: ${{ matrix.row.tools }}
         run: |
           cd ansible
-          ansible-playbook -i localhost, -c local ubuntu.yml --extra-vars user=runner --tags "${{ matrix.tag }}"
+          ansible-playbook -i localhost, -c local ubuntu.yml --extra-vars user=runner --tags "${{ matrix.row.tag }}"
 
   build-mac:
     runs-on: macos-latest

--- a/ansible/roles/mise-tools/tasks/main.yml
+++ b/ansible/roles/mise-tools/tasks/main.yml
@@ -2,5 +2,5 @@
 - name: Install global tools  # noqa command-instead-of-shell
   environment:
     PATH: /usr/local/bin:{{ ansible_env.PATH }}
-  ansible.builtin.shell: "{{ execute }} 'mise -y i'"
+  ansible.builtin.shell: "{{ execute }} 'mise -y i {{ ansible_env.TOOLS }}'"
   changed_when: true


### PR DESCRIPTION
079ab4a Merge pull request #1179 from swfz/feature/maintenance-ansible
aee9ac6 mise python
4d81007 mise pipx
ba312d9 feat: gh extension list
662d45e feat: add chrome
a3fb290 fix: lint
6c61855 fix: auth loginが必要だったので一旦コメントアウトした
2f3c07e fix: change permission
bd3e175 fix: update cache
46eb37e add dependencies
720a4b6 install from deb
e71d191 fix: lint
5544fcd fixed ubuntu version
a88a2ee chore: actionsのrunnerとバージョンを合わせた
42b2dd8 Merge pull request #1185 from swfz/feature/ansible-add-package
b8a00f1 chore: add tool
5355ca4 refactor: タグの見直しとパッケージの配置ロールの変更
564628f feat: update version
178607f refactor: mise管理に変更したものを削除
c71dc12 Merge pull request #1186 from swfz/feature/ansible-maintenance
24e5303 feat: add wslu
d6527d1 Merge pull request #1187 from swfz/feature/ansible-add-wslu
f8050da chore: maintenance
619fdb3 Merge pull request #1188 from swfz/feature/ansible-maintenance
c9ed088 feat: add mise scripts
c2fcca4 fix: lint
16c9db9 fix: update cache
29df601 feat: タグの見直しとvimのmise管理
e1d7707 feat: ci設定の変更
cb1c94b Merge pull request #1189 from swfz/feature/ansible-mise
889dfc9 refactor: remove centos
0ca592f refactor: バージョン指定ツールの整理
4718c15 feat: xclip
112ae2e refactor: remove unused role
6bd03c3 refactor: remove git in redhat
cba7a70 refactor: remove redhat
912a5fc refactor: migrate peco to mise
7adcce1 migrate peco to mise
805d3ec fix: use path
31a4242 fix: lint
1ecc9c9 Merge pull request #1191 from swfz/feature/maintenance-ansible-2
5ba0030 feat: miseのtoolsを分割でインストールする