### PR TITLE
feat(ccsync): 単一ファイル形式のアセットを管理対象に追加

### DIFF
--- a/bin/ccsync.sh
+++ b/bin/ccsync.sh
@@ -18,6 +18,7 @@ Commands:
 
 Examples:
   $(basename "$0") add skills/commit
+  $(basename "$0") add agents/foo.md
   $(basename "$0") link
   $(basename "$0") list
   $(basename "$0") remove skills/commit
@@ -31,24 +32,24 @@ cmd_add() {
   local name="${target#*/}"
 
   if [[ -z "$type" || -z "$name" || "$type" == "$name" ]]; then
-    echo "Error: Invalid format. Use <type>/<name> (e.g., skills/commit)" >&2
+    echo "Error: Invalid format. Use <type>/<name> (e.g., skills/commit, agents/foo.md)" >&2
     exit 1
   fi
 
   local src="${CLAUDE_DIR}/${type}/${name}"
   local dest="${DOTFILES_DIR}/claude/${type}/${name}"
 
-  if [[ ! -d "$src" ]]; then
-    echo "Error: Source directory does not exist: ${src}" >&2
-    exit 1
-  fi
-
   if [[ -L "$src" ]]; then
     echo "Error: ${src} is already a symlink" >&2
     exit 1
   fi
 
-  if [[ -d "$dest" ]]; then
+  if [[ ! -e "$src" ]]; then
+    echo "Error: Source does not exist: ${src}" >&2
+    exit 1
+  fi
+
+  if [[ -e "$dest" ]]; then
     echo "Error: Destination already exists: ${dest}" >&2
     exit 1
   fi
@@ -74,10 +75,10 @@ cmd_link() {
     local type
     type="$(basename "$type_dir")"
 
-    for asset_dir in "${type_dir}"/*/; do
-      [[ -d "$asset_dir" ]] || continue
+    for asset_path in "${type_dir}"*; do
+      [[ -e "$asset_path" ]] || continue
       local name
-      name="$(basename "$asset_dir")"
+      name="$(basename "$asset_path")"
       local target="${CLAUDE_DIR}/${type}/${name}"
       local src="${dotfiles_claude}/${type}/${name}"
 
@@ -93,8 +94,8 @@ cmd_link() {
         continue
       fi
 
-      if [[ -d "$target" ]]; then
-        echo "Warning: ${target} exists as a regular directory (skipping)" >&2
+      if [[ -e "$target" ]]; then
+        echo "Warning: ${target} already exists (skipping)" >&2
         warned=$((warned + 1))
         continue
       fi
@@ -119,10 +120,10 @@ cmd_list() {
     local type
     type="$(basename "$type_dir")"
 
-    for asset_dir in "${type_dir}"/*/; do
-      [[ -d "$asset_dir" ]] || continue
+    for asset_path in "${type_dir}"*; do
+      [[ -e "$asset_path" ]] || continue
       local name
-      name="$(basename "$asset_dir")"
+      name="$(basename "$asset_path")"
       local target="${CLAUDE_DIR}/${type}/${name}"
       local src="${dotfiles_claude}/${type}/${name}"
       local status
@@ -135,8 +136,8 @@ cmd_list() {
         else
           status="conflict (-> ${current_link})"
         fi
-      elif [[ -d "$target" ]]; then
-        status="not linked (directory exists)"
+      elif [[ -e "$target" ]]; then
+        status="not linked (exists)"
       else
         status="not linked"
       fi
@@ -157,14 +158,14 @@ cmd_remove() {
   local name="${target#*/}"
 
   if [[ -z "$type" || -z "$name" || "$type" == "$name" ]]; then
-    echo "Error: Invalid format. Use <type>/<name> (e.g., skills/commit)" >&2
+    echo "Error: Invalid format. Use <type>/<name> (e.g., skills/commit, agents/foo.md)" >&2
     exit 1
   fi
 
   local dotfiles_path="${DOTFILES_DIR}/claude/${type}/${name}"
   local claude_path="${CLAUDE_DIR}/${type}/${name}"
 
-  if [[ ! -d "$dotfiles_path" ]]; then
+  if [[ ! -e "$dotfiles_path" ]]; then
     echo "Error: Not managed: ${target}" >&2
     exit 1
   fi


### PR DESCRIPTION
## 概要

`bin/ccsync.sh` をディレクトリ単位アセット (`skills/commit/` など) に加えて、単一ファイル形式のアセット (`agents/foo.md` など) も管理できるよう拡張した。

## why

`~/.claude/agents/` 配下は `.md` ファイルが直置きされる構造で、ccsync.sh の従来実装ではディレクトリ前提 (`-d` チェック) のため `add` 時点で「Source directory does not exist」と弾かれて取り込めなかった。skills と agents を同じ仕組みで dotfiles に集約したかったので、ファイル単位もサポートする。

## how

- `cmd_add` / `cmd_remove`: 存在チェックを `-d` から `-e` に緩和
- `cmd_link` / `cmd_list`: 内側ループの glob を `*/` (ディレクトリのみ) → `*` (ファイル/ディレクトリ両方) に変更し、判定も `-e` ベースに
- `cmd_add` のチェック順序を整理: `-L` (symlink 既設) を先に判定 (symlink ターゲットが存在する場合に `-e` が true を返してしまうため)
- `cp -R` / `rm -rf` / `ln -s` はファイル/ディレクトリ両対応なので処理本体は変更なし
- usage と error メッセージに `agents/foo.md` の例を追記

なお `~/.claude/agents/swfz.md` はプライベート別リポジトリから symlink されているため、すでに symlink である分岐 (`Error: ... is already a symlink`) で安全に弾かれる。

## 確認観点

- [x] `bash -n` 構文チェック通過
- [x] 既存の `skills/*` 7件のリンク状態が変わらない (`list` で全て `[linked]`)
- [x] ファイル単位のラウンドトリップ動作確認 (`agents/__ccsync_test__.md` をダミーに作成)
  - [x] `add` でコピー＆symlink化される
  - [x] `list` でファイルアセットも一覧に出る
  - [x] `link` が冪等 (既存リンクをスキップ)
  - [x] symlink 化済みに対する `add` は `Error: ... is already a symlink` で弾かれる
  - [x] `remove` で symlink を消し、ファイルが元の場所に復元される
- [x] テスト後、dotfiles と `~/.claude/` に余分な残骸がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)