### PR TITLE
chore(workflows): create-github-app-token の app-id 廃止予定に追従

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -73,7 +73,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: swfz
           repositories: dotfiles


### PR DESCRIPTION
## 概要

`update-versions` workflow で利用している `actions/create-github-app-token` の入力フィールドを `app-id` から `client-id` へ移行する。

## Why

- `actions/create-github-app-token` v3 系で `app-id` 入力に対し以下の deprecation 警告が出るようになった
  - `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`
- 将来的に `app-id` が削除された際にビルドが破綻するのを避けるため、推奨値である `client-id` へ予防的に切り替える

## How

- `.github/workflows/update-versions.yml` で `app-id: \${{ secrets.APP_ID }}` を `client-id: \${{ secrets.APP_CLIENT_ID }}` に変更
- secret 参照名も `APP_ID` → `APP_CLIENT_ID` に変更し、保持する値が App ID (数値) ではなく Client ID (英数字) であることを明示

## 確認観点

- [ ] GitHub リポジトリの Secrets に `APP_CLIENT_ID` を追加済み（GitHub App 設定ページの Client ID をコピー）
- [ ] workflow を `workflow_dispatch` で手動実行し、`Generate token` ステップが成功する
- [ ] `create pull request` ステップで PR が正しく作成できる（差分があるロールが対象になったタイミングで確認）
- [ ] deprecation 警告が出なくなっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)