### PR TITLE
feat(claude): ターミナル風スライドデッキ生成スキル slide-style-terminal を追加

### DIFF
--- a/claude/skills/slide-style-terminal/SKILL.md
+++ b/claude/skills/slide-style-terminal/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: slide-style-terminal
+description: ターミナルウィンドウ風のエンジニア向けダークスライドデッキ (信号機ドット+パスのタイトルバー / ピンクの ❯ シェブロン見出し / tree コマンド風の結線ツリー箇条書き / ファイル名タブ付き多色コード / DuckDB CLI 風 ASCII テーブル出力 / powerline・tmux 風ステータスライン / 点滅カーソル / 16:9 レターボックス) を、単一 HTML で生成し Artifact として公開するスキル。「ターミナル風スライド」「あのダークなスライドスタイルで」「slide-style-terminal」「LT資料をあのスタイルで」などの依頼や、コマンド出力・SQL・コードを見せる技術系のプレゼン/LT/発表資料を作る場面で使う。GUI操作の集計レポート (drilldown-report / timeseries-report / gui-report) とは別物 (あちらはデータ可視化)。
+---
+
+# slide-style-terminal
+
+エンジニア向け LT・技術発表のための **ターミナルウィンドウ風ダークスライド** を、
+外部リソースに依存しない単一 HTML として生成する。Artifact 公開・ローカル閲覧の両方で使える。
+
+## デザインの要点 (これがスタイルの本体)
+
+| 要素 | 仕様 |
+|------|------|
+| スライド枠 | **ターミナルウィンドウ**化。信号機ドット + `swfz@mac: ~/talks/… — zsh` のタイトルバー、角丸・ドロップシャドウ |
+| 背景 | デッキ外は `#12181f` + ビネット、スライド地は `#2b3646`。微かな**スキャンライン** |
+| フォント | 等幅 (`ui-monospace` 系)。日本語はシステムのゴシックにフォールバック |
+| 見出し | 先頭にピンクの `❯` シェブロン (`--accent #e23f7a`) + 白テキスト |
+| 箇条書き | **`tree` コマンド風の結線**。縦スパイン `│` + エルボー `├`/`└` を CSS 罫線で描画。深いほど小さく淡く |
+| コード | **ファイル名タブ**(`● users.json`)付き。中身にフィットする幅。多色シンタックス |
+| 端末出力 | DuckDB CLI 風の **ASCII 罫線テーブル** を `<pre class="term">` に生貼り。行頭 `D`/`$`/`❯` は緑 |
+| シンタックス色 | キーワード=ピンク `.kw` / 関数・キー=青 `.fn` / 文字列=緑 `.str` / 数値=琥珀 `.num` / コメント=灰斜体 `.com` |
+| 2カラム | `.cols` で左右分割。左コード / 右出力などの対比に |
+| 画像 | **白背景ボックス**に収める (`.figure img`)。下にシアン下線リンクの出典 |
+| フッタ | 下端に **powerline / tmux 風ステータスライン** (`NORMAL` モード → `git:main` → ファイル名 → `utf-8` → `N/総数`)。矢印は Nerd Font ではなく CSS clip-path で描画 |
+| タイトル | **ブート風プロンプト** (`❯ ./present.sh …`) + 大きな等幅タイトル + **点滅カーソル** |
+| 版面 | **16:9 レターボックス**。container query (cqw/cqh) でウィンドウ幅に追従 |
+
+色・レイアウトの実体はすべて `assets/template.html` の `:root` 変数と CSS にある。**まず読むこと。**
+
+## ワークフロー
+
+1. **`assets/template.html` を読む。** 全コンポーネントを含む動くリファレンスデッキ (DuckDB 例) を兼ねる。
+2. **内容を差し替える。** タイトルスライド + 各スライドを、下記コンポーネントを組み合わせて作る。
+   - 1トピック = 1 `<section class="slide">` → `<div class="slide-inner">` の中に `.win-bar` / `.win-body` / `.status` の3段。
+   - `.win-bar` のパス表示と `.status` の `git:` ブランチ・ファイル名・モードは**発表テーマに合わせて書き換える**と世界観が締まる。
+   - ページ番号は `.status` の `.seg--count` 内 `<span class="pageno">N</span>/総数` を更新。タイトルは `1`。
+3. **画像は data: URI で埋め込む** (Artifact は外部URL・CDN・フォント読み込みを CSP でブロックする)。
+   - ローカル画像 → base64 化して `<img src="data:image/png;base64,...">`。
+4. **出力**
+   - **Artifact 公開** (既定): このテンプレートは doctype/html/head/body を持たない**フラグメント**なので、そのまま Artifact ツールに渡せる。**先に `artifact-design` スキルを読む** (Artifact ツールの要件)。`favicon` は端末系の絵文字 (例 `🖥️` `⚡`) を渡す。
+   - **ローカル HTML** で欲しい場合はファイルパスを渡す。WSL なので `file:///...` と `file://wsl.localhost/Ubuntu/...` の両方を返す。
+5. **操作確認**: `← → / Space / PageUp・Down` でスライド移動できる。Artifact 公開後や画面確認が要る場合は Playwright で最低限の表示・キー操作を確認する。
+
+## コンポーネント早見表
+
+すべて `template.html` に実例がある。クラス名だけ抜粋:
+
+- **ウィンドウ枠**: `.slide-inner` に `.win-bar`(信号機ドット `.dot.r/.y/.g` + `.win-title`) / `.win-body` / `.status` の3段
+- **タイトル**: `.win-body` に `.boot`(プロンプト行) + `.title-main`(+`.cursor` 点滅) + `.title-sub`
+- **見出し**: `<h2 class="head">…</h2>` (`❯` は ::before で自動付与)
+- **ツリー箇条書き**: `<ul class="tree">` に `<li>` をネスト。結線は CSS 自動。コード語は `.kw`/`.fn`/`.str`/`.num`/`.com`/`.dim` で着色
+- **コード**: `.code-wrap` に `.code-tab`(ファイル名) + `<pre class="code">`。中は色 span で装飾
+- **端末出力**: `<pre class="term">` に ASCII テーブルを生貼り。プロンプト行は `<span class="p">`
+- **2カラム**: `<div class="cols">` に子2つ
+- **画像**: `<figure class="figure">` → `<img>` + `<figcaption>` (出典は `<a class="link">`)
+- **ステータスライン**: `.status` に `.seg--mode` / `.seg--branch` / `.seg--file` / `.seg--spring`(伸縮) / `.seg--info` / `.seg--count`
+
+## 注意
+
+- **等幅フォントが世界観の核**。日本語も等幅系にフォールバックさせる (テンプレの `--mono` を触らない)。
+- テキスト量が多いと 16:9 からはみ出る。`cqw`/`cqh` 基準なので**1スライドの情報量を絞る**のが正解 (元スタイルも余白が多い)。
+- 端末出力の ASCII テーブルは**実際のコマンド出力を貼る**のが最も本物らしい。整形しすぎない。
+- powerline 矢印・信号機ドットは **CSS だけで描画**している (Nerd Font に依存しない) ので Artifact でもそのまま出る。
+- グラフや集計の可視化が主目的なら、このスキルではなく `drilldown-report` / `timeseries-report` を使う。

--- a/claude/skills/slide-style-terminal/assets/template.html
+++ b/claude/skills/slide-style-terminal/assets/template.html
@@ -1,0 +1,347 @@
+<title>スライドタイトル</title>
+<style>
+  /* ============================================================
+     slide-style-terminal : ターミナルウィンドウ風スライドデッキ
+     - Artifact 用フラグメント (doctype/html/head/body は書かない)
+     - 外部リソース禁止。フォント・画像は data: URI で埋め込むこと
+     - Nerd Font 不使用 (powerline 矢印は CSS clip-path で描画)
+     ============================================================ */
+  :root {
+    --deck-bg: #12181f;   /* デッキ外 (レターボックス) */
+    --win:     #2b3646;   /* ウィンドウ本体 (スライド地) */
+    --bar:     #232d3a;   /* タイトルバー / ステータス地 */
+    --fg:      #d6dce1;   /* 主テキスト */
+    --muted:   #7c8a99;   /* 副次・結線・パス */
+    --accent:  #e23f7a;   /* ブランドのピンク */
+    --line:    #3c4a5a;   /* 罫線・ツリー結線・枠 */
+    --kw:      #e23f7a;   /* SQLキーワード (SELECT/FROM) */
+    --fn:      #7fb4d8;   /* 関数・キー (read_json / "id") */
+    --str:     #9ece6a;   /* 文字列 */
+    --num:     #e0a06a;   /* 数値 */
+    --com:     #6b7684;   /* コメント */
+    --prompt:  #9ece6a;   /* プロンプト記号 (D / $ / ❯) */
+    --link:    #5fb2c8;
+    --code-bg: #1f2833;   /* コードブロック地 */
+    --term-bg: #1a222c;   /* 端末出力地 */
+    --mono: ui-monospace, "SF Mono", "Cica", "HackGen", Menlo, Consolas,
+            "Noto Sans Mono CJK JP", "Yu Gothic", "Hiragino Kaku Gothic ProN", monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background:
+      repeating-linear-gradient(0deg, rgba(0,0,0,.10) 0 1px, transparent 1px 3px), /* 微かなスキャンライン */
+      radial-gradient(120% 120% at 50% 0%, #1a222c 0%, var(--deck-bg) 70%);
+    color: var(--fg);
+    font-family: var(--mono);
+    -webkit-font-smoothing: antialiased;
+  }
+  .deck { scroll-snap-type: y mandatory; }
+
+  /* --- スライド枠: 16:9 レターボックス --- */
+  .slide {
+    height: 100vh;
+    display: flex; align-items: center; justify-content: center;
+    scroll-snap-align: start;
+    padding: 2.2vh 2vw;
+  }
+  /* --- ターミナルウィンドウ本体 --- */
+  .slide-inner {
+    position: relative;
+    width: min(100%, calc((100vh - 4.4vh) * 16 / 9));
+    aspect-ratio: 16 / 9;
+    background: var(--win);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    box-shadow: 0 24px 60px rgba(0,0,0,.5), 0 2px 0 rgba(255,255,255,.03) inset;
+    overflow: hidden;
+    display: flex; flex-direction: column;
+    container-type: size;   /* cqw/cqh の基準。幅に追従してスケール */
+  }
+
+  /* --- タイトルバー (信号機 + パス) --- */
+  .win-bar {
+    flex: 0 0 auto;
+    height: 6.4cqh;
+    display: flex; align-items: center; gap: .8cqw;
+    padding: 0 2.4cqw;
+    background: var(--bar);
+    border-bottom: 1px solid var(--line);
+    font-size: 1.9cqw; color: var(--muted);
+  }
+  .dot { width: 1.5cqw; height: 1.5cqw; border-radius: 50%; }
+  .dot.r { background: #ec6a5e; } .dot.y { background: #f4bf4f; } .dot.g { background: #61c554; }
+  .win-title { margin-left: 1.6cqw; }
+  .win-title b { color: #aeb9c4; font-weight: 600; }
+
+  /* --- 本文エリア --- */
+  .win-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    padding: 4.2cqh 4cqw 3cqh;
+    display: flex; flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* --- 見出し (プロンプト風) --- */
+  .head {
+    display: flex; align-items: baseline; gap: .5em;
+    font-size: 5cqw; font-weight: 700; letter-spacing: .01em;
+    margin: 0 0 2.6cqh; line-height: 1.1;
+  }
+  .head::before { content: "\276F"; color: var(--accent); }  /* ❯ */
+  .cursor {   /* 点滅ブロックカーソル */
+    display: inline-block; width: .5em; height: 1em;
+    background: var(--accent); margin-left: .1em;
+    transform: translateY(.12em);
+    animation: blink 1.05s steps(1) infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+
+  /* --- ツリー箇条書き (tree コマンド風の結線) --- */
+  .tree, .tree ul { list-style: none; margin: 0; padding: 0; }
+  .tree ul { margin-left: 1.1em; }
+  .tree li {
+    position: relative;
+    padding-left: 1.5em;
+    margin: .3cqh 0;
+    font-size: 2.9cqw; line-height: 1.5;
+  }
+  .tree li::before {   /* 縦線 │ */
+    content: ""; position: absolute; left: .25em; top: 0; bottom: 0;
+    width: 1px; background: var(--line);
+  }
+  .tree li:last-child::before { bottom: calc(100% - .78em); }  /* └ の脚: ティックまでで止める */
+  .tree li::after {    /* 横線 ─ (エルボー) */
+    content: ""; position: absolute; left: .25em; top: .78em;
+    width: .85em; height: 1px; background: var(--line);
+  }
+  .tree ul li { font-size: 2.55cqw; color: #c3ccd4; }
+  .tree ul ul li { font-size: 2.35cqw; color: var(--muted); }
+
+  /* --- インライン・シンタックス色 --- */
+  .kw{color:var(--kw)} .fn{color:var(--fn)} .str{color:var(--str)}
+  .num{color:var(--num)} .com{color:var(--com);font-style:italic} .dim{color:var(--muted)}
+
+  /* --- タイトルスライド (ブート風) --- */
+  .boot { font-size: 2.5cqw; line-height: 1.7; color: var(--muted); }
+  .boot .p { color: var(--prompt); }
+  .title-main { font-size: 9cqw; font-weight: 700; letter-spacing: .02em; color: #eef2f5; margin-top: 1.5cqh; }
+  .title-sub  { font-size: 2.8cqw; color: var(--muted); margin-top: 1cqh; }
+
+  /* --- コードブロック (ファイル名タブ付き) --- */
+  .code-wrap { display: flex; flex-direction: column; min-height: 0; align-items: flex-start; }
+  .code-tab {
+    font-size: 1.9cqw; color: var(--fg);
+    background: var(--code-bg); border: 1px solid var(--line); border-bottom: none;
+    padding: .5cqh 1.6cqw; border-radius: 6px 6px 0 0;
+  }
+  .code-tab::before { content: "\25CF "; color: var(--num); }  /* 未保存風ドット ● */
+  pre.code, pre.term {
+    margin: 0; font-family: var(--mono); white-space: pre; overflow: auto;
+    width: fit-content; max-width: 100%;   /* 中身にフィット (余白を作らない) */
+    background: var(--code-bg); border: 1px solid var(--line); border-radius: 0 6px 6px 6px;
+    padding: 2cqh 2cqw; font-size: 2.1cqw; line-height: 1.5; color: var(--fg);
+  }
+  pre.term {
+    border-radius: 6px; font-size: 1.5cqw; line-height: 1.35; color: #c3ccd4;
+    background: var(--term-bg);
+  }
+  pre.term .p { color: var(--prompt); }   /* D / $ プロンプト */
+
+  /* --- 2カラム --- */
+  .cols { flex: 1; display: grid; grid-template-columns: 1fr 1fr; gap: 3cqw; min-height: 0; }
+  .cols > * { min-width: 0; display: flex; flex-direction: column; }
+
+  /* --- 画像 (白背景ボックスに収める) --- */
+  .figure { text-align: center; margin: 0; }
+  .figure img { max-width: 100%; max-height: 55cqh; background: #fff; padding: 1.2cqw; border-radius: 4px; }
+  .figure figcaption { margin-top: 2cqh; font-size: 2.1cqw; }
+  a.link { color: var(--link); text-decoration: underline; }
+
+  /* --- ステータスライン (powerline / lightline 風) --- */
+  .status {
+    flex: 0 0 auto;
+    display: flex; align-items: stretch;
+    height: 5.4cqh; font-size: 1.9cqw;
+    background: var(--bar); border-top: 1px solid var(--line);
+  }
+  .seg { display: flex; align-items: center; padding: 0 1.8cqw; white-space: nowrap; }
+  .seg--mode { background: var(--accent); color: #17202a; font-weight: 700; position: relative; }
+  .seg--mode::after {   /* powerline の右向き矢印 */
+    content: ""; position: absolute; right: -1.2cqh; top: 0; bottom: 0;
+    width: 1.2cqh; background: var(--accent);
+    clip-path: polygon(0 0, 0 100%, 100% 50%);
+  }
+  .seg--branch { background: #38465a; color: #cfd8e0; margin-left: 1.2cqh; }
+  .seg--file   { color: var(--muted); }
+  .seg--spring { flex: 1; }
+  .seg--info   { color: var(--muted); }
+  .seg--count  { background: var(--accent); color: #17202a; font-weight: 700; position: relative; }
+  .seg--count::before {   /* powerline の左向き矢印 */
+    content: ""; position: absolute; left: -1.2cqh; top: 0; bottom: 0;
+    width: 1.2cqh; background: var(--accent);
+    clip-path: polygon(100% 0, 0 50%, 100% 100%);
+  }
+
+  @media print { .slide { height: auto; page-break-after: always; } }
+</style>
+
+<div class="deck">
+
+  <!-- ============ タイトル (ブート風) ============ -->
+  <section class="slide">
+    <div class="slide-inner">
+      <div class="win-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="win-title">swfz@mac: <b>~/talks/duckdb</b> — zsh</span>
+      </div>
+      <div class="win-body" style="justify-content:center">
+        <div class="boot">
+<span class="p">❯</span> ./present.sh --topic duckdb
+<span class="dim">▶ loading deck ...</span> <span class="str">ready</span>
+        </div>
+        <div class="title-main">DuckDB<span class="cursor"></span></div>
+        <div class="title-sub">澤藤勇也</div>
+      </div>
+      <div class="status">
+        <span class="seg seg--mode">NORMAL</span>
+        <span class="seg seg--branch">git:main</span>
+        <span class="seg seg--file">deck.html</span>
+        <span class="seg seg--spring"></span>
+        <span class="seg seg--info">utf-8 &nbsp; duckdb</span>
+        <span class="seg seg--count"><span class="pageno">1</span>/12</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ ツリー箇条書き ============ -->
+  <section class="slide">
+    <div class="slide-inner">
+      <div class="win-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="win-title">swfz@mac: <b>~/talks/duckdb</b> — zsh</span>
+      </div>
+      <div class="win-body">
+        <h2 class="head">DuckDB?</h2>
+        <ul class="tree">
+          <li><span class="kw">SQLite</span> の OLAP 版
+            <ul>
+              <li>分析用途</li>
+              <li>Notebook で使われるようなライブラリで使われていたり
+                <ul><li>PyGWalker</li></ul>
+              </li>
+            </ul>
+          </li>
+          <li>様々な種類のデータを読み込める</li>
+        </ul>
+      </div>
+      <div class="status">
+        <span class="seg seg--mode">NORMAL</span>
+        <span class="seg seg--branch">git:main</span>
+        <span class="seg seg--file">deck.html</span>
+        <span class="seg seg--spring"></span>
+        <span class="seg seg--info">utf-8 &nbsp; duckdb</span>
+        <span class="seg seg--count"><span class="pageno">2</span>/12</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ 2カラム: コード + 端末出力 ============ -->
+  <section class="slide">
+    <div class="slide-inner">
+      <div class="win-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="win-title">swfz@mac: <b>~/talks/duckdb</b> — zsh</span>
+      </div>
+      <div class="win-body">
+        <div class="cols">
+          <div>
+            <h2 class="head" style="font-size:3.6cqw">JSON ファイル</h2>
+            <div class="code-wrap">
+              <span class="code-tab">users.json</span>
+<pre class="code">[
+  {
+    <span class="fn">"id"</span>: <span class="num">1</span>,
+    <span class="fn">"name"</span>: <span class="str">"Alice"</span>,
+    <span class="fn">"age"</span>: <span class="num">30</span>
+  }
+]</pre>
+            </div>
+          </div>
+          <div>
+            <h2 class="head" style="font-size:3.6cqw">読み込み</h2>
+<pre class="term"><span class="p">D</span> <span class="kw">SELECT</span> * <span class="kw">FROM</span> <span class="fn">read_json</span>(<span class="str">'users.json'</span>);
+┌───────┬─────────┬───────┐
+│  id   │  name   │  age  │
+│ int64 │ varchar │ int64 │
+├───────┼─────────┼───────┤
+│   1   │ Alice   │   30  │
+│   2   │ Bob     │   25  │
+└───────┴─────────┴───────┘</pre>
+          </div>
+        </div>
+      </div>
+      <div class="status">
+        <span class="seg seg--mode">NORMAL</span>
+        <span class="seg seg--branch">git:main</span>
+        <span class="seg seg--file">query.sql</span>
+        <span class="seg seg--spring"></span>
+        <span class="seg seg--info">sql &nbsp; duckdb</span>
+        <span class="seg seg--count"><span class="pageno">7</span>/12</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ 画像スライド ============ -->
+  <section class="slide">
+    <div class="slide-inner">
+      <div class="win-bar">
+        <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+        <span class="win-title">swfz@mac: <b>~/talks/duckdb</b> — zsh</span>
+      </div>
+      <div class="win-body">
+        <h2 class="head">インストール</h2>
+        <div class="code-wrap">
+          <span class="code-tab">install.sh</span>
+<pre class="code"><span class="p">$</span> brew install duckdb</pre>
+        </div>
+        <figure class="figure" style="margin-top:3cqh">
+          <!-- 画像は data: URI で埋め込む (外部URL不可) -->
+          <!-- <img src="data:image/png;base64,..." alt=""> -->
+          <figcaption><a class="link" href="#">DuckDB Installation</a></figcaption>
+        </figure>
+      </div>
+      <div class="status">
+        <span class="seg seg--mode">NORMAL</span>
+        <span class="seg seg--branch">git:main</span>
+        <span class="seg seg--file">install.sh</span>
+        <span class="seg seg--spring"></span>
+        <span class="seg seg--info">sh &nbsp; duckdb</span>
+        <span class="seg seg--count"><span class="pageno">5</span>/12</span>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<script>
+  // ← → / Space / PageUp・Down でスライド移動
+  (function () {
+    var slides = Array.prototype.slice.call(document.querySelectorAll('.slide'));
+    function cur() {
+      var y = window.scrollY + window.innerHeight / 2;
+      for (var i = 0; i < slides.length; i++)
+        if (slides[i].offsetTop <= y && slides[i].offsetTop + slides[i].offsetHeight > y) return i;
+      return 0;
+    }
+    function go(i) {
+      i = Math.max(0, Math.min(slides.length - 1, i));
+      slides[i].scrollIntoView({ behavior: 'smooth' });
+    }
+    document.addEventListener('keydown', function (e) {
+      if (['ArrowRight','ArrowDown','PageDown',' '].indexOf(e.key) >= 0) { go(cur() + 1); e.preventDefault(); }
+      else if (['ArrowLeft','ArrowUp','PageUp'].indexOf(e.key) >= 0) { go(cur() - 1); e.preventDefault(); }
+    });
+  })();
+</script>


### PR DESCRIPTION
## 概要

コマンド出力・SQL・コードを見せる技術系 LT/発表資料を「ターミナルウィンドウ風」のダークデッキとして生成し、Artifact 公開できる新スキル `slide-style-terminal` を追加する。既存の DuckDB スライド（PowerPoint 製）のスタイルを出発点に、HTML ならではの表現でブラッシュアップした。

## why（背景・理由）

- PowerPoint ではあのターミナル風スタイルの再現が限界だった
- HTML なら本物のエンジニアツールの語彙（ウィンドウ枠・tree 出力・powerline ステータスライン等）で表現でき、コード/コマンド出力を見せる発表に最適
- 単一 HTML・外部依存なしなので、そのまま Artifact として共有・公開できる

## how（手法）

- `SKILL.md` にデザイン仕様（色・レイアウト・コンポーネント早見表）とワークフローを記載
- `assets/template.html` に全コンポーネント入りの動くリファレンスデッキを実装
  - ターミナルウィンドウ枠（信号機ドット + パスのタイトルバー）
  - `tree` コマンド風の結線ツリー箇条書き（CSS 罫線で描画）
  - ファイル名タブ付き多色コード / DuckDB CLI 風 ASCII テーブル出力
  - powerline・tmux 風ステータスライン（矢印は Nerd Font 非依存の CSS clip-path）
  - 点滅カーソル・16:9 レターボックス（container query で幅追従）

## 確認観点

- [x] Playwright で各スライド（タイトル / ツリー箇条書き / 2カラム+端末 / 画像）が意図通りレンダリングされることを確認
- [x] powerline 矢印・信号機ドット・ツリー結線が Nerd Font なしで描画される（Artifact の CSP 制約下でも表示可能）
- [x] `← → / Space` でのスライド移動が動作
- [x] テンプレートは doctype/html/head/body を持たないフラグメントで、Artifact ツールにそのまま渡せる

🤖 Generated with [Claude Code](https://claude.com/claude-code)