### PR TITLE
feat: Toggl APIプロキシをsystemdユーザーサービスとして常駐化

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -86,6 +86,9 @@ ruby・nodejs・python・golangの`starship`モジュールを高速に実行す
 ## setup-monitor-mtg.sh
 カメラ/マイクの利用を監視するsystemdユーザーサービスをセットアップする。
 
+## setup-toggl-proxy.sh
+Toggl APIプロキシサーバ（`~/memo/apps/ts-input/server/toggl2ts-server.rb`、Toggl→TeamSpiritマッピングのローカルAPI）をsystemdユーザーサービスとしてセットアップする。トークンは `~/.config/toggl/api.env` に `TOGGL_TOKEN` を記載する（toggl-*系サービスで共有）。
+
 ## switchbot
 SwitchBot API v1.1 を直接叩いてデバイスを on/off する。`SWITCHBOT_TOKEN` / `SWITCHBOT_SECRET` / `SWITCHBOT_DEVICE_ID` を環境変数で渡す。Ruby gem 依存をやめたのでランタイム差し替えの影響を受けない。
 

--- a/bin/setup-toggl-proxy.sh
+++ b/bin/setup-toggl-proxy.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Toggl APIプロキシサーバ（~/memo/apps/ts-input/server/toggl2ts-server.rb）を
+# systemdユーザーサービスとして常駐させるセットアップスクリプト
+# 前提
+#   WSL環境でsystemdを利用
+#   Rubyはmise管理（shim経由で起動するのでバージョン更新の影響を受けない）
+#   webrick gemがインストール済みであること（gem install webrick）
+# トークンは ~/.config/toggl/api.env に置く（toggl-* 系サービスで共有する想定）
+
+set -e
+
+echo "=== Setting up Toggl Proxy Service ==="
+
+DOTFILES_DIR="$HOME/dotfiles"
+SERVICE_SRC="$DOTFILES_DIR/systemd/toggl-proxy.service"
+
+mkdir -p "$HOME/.config/systemd/user"
+ln -sf "$SERVICE_SRC" "$HOME/.config/systemd/user/toggl-proxy.service"
+echo "✅ Linked service file"
+
+TOGGL_DIR="$HOME/.config/toggl"
+TOGGL_FILE="$TOGGL_DIR/api.env"
+
+if [ ! -f "$TOGGL_FILE" ]; then
+    echo "⚠️  WARNING: Token file not found at $TOGGL_FILE"
+    echo "   Creating directory..."
+    mkdir -p "$TOGGL_DIR"
+    echo "   Please create 'api.env' with TOGGL_TOKEN (and optionally TOGGL_WORKSPACE_ID / TOGGL2TS_PORT) manually."
+else
+    echo "✅ Toggl env file found."
+fi
+
+echo "🔄 Reloading systemd..."
+systemctl --user daemon-reload
+systemctl --user enable toggl-proxy
+systemctl --user restart toggl-proxy
+
+echo "=== Setup Complete! ==="
+systemctl --user status toggl-proxy --no-pager | head -n 10

--- a/systemd/toggl-proxy.service
+++ b/systemd/toggl-proxy.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Toggl API proxy server (ts-input Toggl->TeamSpirit mapping)
+After=network.target
+
+[Service]
+EnvironmentFile=%h/.config/toggl/api.env
+ExecStart=%h/.local/share/mise/shims/ruby %h/memo/apps/ts-input/server/toggl2ts-server.rb
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## 概要

ts-input（TeamSpirit工数入力 Chrome拡張）のToggl連携で使うローカルAPIサーバ（`~/memo/apps/ts-input/server/toggl2ts-server.rb`）を、systemdユーザーサービス `toggl-proxy` として常駐させる。

## why

- 拡張機能のTogglタブを使うたびに、ターミナルを開いて `TOGGL_TOKEN=xxx ruby server/toggl2ts-server.rb` を手動起動し、開いたままにしておく必要があった
- WSL起動時に自動で立ち上がるようにして、この手間をなくす

## how

- `systemd/toggl-proxy.service`: ユニットファイル本体。既存の `mtg-monitor` と同じパターン
  - Rubyはmiseのshim（`%h/.local/share/mise/shims/ruby`）経由で起動し、Rubyバージョン更新の影響を受けないようにする
  - トークンは `EnvironmentFile=%h/.config/toggl/api.env` に分離。今後追加予定の toggl-* 系サービス（日次のtoggl-summaryなど）でも同じファイルを共有する想定
- `bin/setup-toggl-proxy.sh`: `~/.config/systemd/user/` へのリンク作成、daemon-reload / enable / restart を行うセットアップスクリプト（`setup-monitor-mtg.sh` と同構成）
- `bin/README.md` に説明を追記

## 確認観点

実機（WSL）でセットアップスクリプトを実行し、サービスの稼働とAPI疎通まで確認済み。

- [x] `setup-toggl-proxy.sh` 実行でサービスが enable される
- [x] `api.env` 未作成時は起動失敗し、セットアップスクリプトが警告を出す（switchbotと同じ運用）
- [x] `api.env` 作成後、`systemctl --user restart toggl-proxy` で `active (running)` になる
- [x] `GET /worklog` でToggl API呼び出し〜マッピング結果の取得が正常に返る
- [x] pre-commit の secretlint 通過（トークン混入なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)