### PR TITLE
fix: toggl-proxy起動前にgemの存在チェックを実行

### DIFF
--- a/systemd/toggl-proxy.service
+++ b/systemd/toggl-proxy.service
@@ -4,6 +4,9 @@ After=network.target
 
 [Service]
 EnvironmentFile=%h/.config/toggl/api.env
+# miseのRuby更新後にgem未インストールで起動失敗するのを防ぐ（gem installが走る場合があるためタイムアウトは長め）
+ExecStartPre=%h/memo/apps/ts-input/server/ensure-gems.sh
+TimeoutStartSec=300
 ExecStart=%h/.local/share/mise/shims/ruby %h/memo/apps/ts-input/server/toggl2ts-server.rb
 Restart=always
 


### PR DESCRIPTION
## 概要

toggl-proxy サービスの起動前に、必要な gem の存在チェック＋自動インストール（`ExecStartPre`）を行うようにする。

## why

- mise が Ruby を新バージョンへ更新すると gem が未インストールの状態になり、サーバが LoadError で起動ループに陥る
- 実際に Ruby 4.0.5 → 4.0.6 の更新で toggl-proxy が起動不能になった（webrick / activesupport / awesome_print が欠落）
- サービスは常駐前提なので、Ruby 更新のたびに手動で gem を入れ直す運用を避けたい

## how

- `ExecStartPre=%h/memo/apps/ts-input/server/ensure-gems.sh` を追加。gem リストはアプリ側の依存なので、スクリプト本体は memo リポジトリ（アプリと同じ場所）に置く（swfz/memo e60d047 相当で追加済み）
- gem install が走るケースに備えて `TimeoutStartSec=300` を設定

## 確認観点

実機（WSL）で以下を確認済み。

- [x] gem が揃っている場合、ensure-gems.sh は no-op で通過する
- [x] `awesome_print` を意図的にアンインストール → ensure-gems.sh が検知して自動再インストールする
- [x] `daemon-reload` 後の `systemctl --user restart toggl-proxy` で ExecStartPre 経由で起動し、`GET /jobs` が 200 を返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)